### PR TITLE
Fixed Cholesky timer output and optimized layout conversion for gemm.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(cholesky CXX C)
+project(DLA_interface CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/include/distributed_matrix.h
+++ b/include/distributed_matrix.h
@@ -182,6 +182,12 @@ namespace dla_interface {
       return res;
     }
 #endif
+    // Returns true if this and are the same matrix, i.e.
+    // - *this and rhs have the same shape,
+    // - *this and rhs are distributed in the same way,
+    // - *this and rhs reference the same memory.
+    bool isSameMatrix(const DistributedMatrix& rhs) const;
+
     // Copies the value of the elements of rhs.
     // Throws std::invalid_argument if *this and rhs do not have the same size.
     // If size() and rhs.size() != (0, 0):

--- a/include/distributed_matrix.ipp
+++ b/include/distributed_matrix.ipp
@@ -138,6 +138,20 @@ DistributedMatrix<ElType>& DistributedMatrix<ElType>::operator=(DistributedMatri
 }
 
 template <class ElType>
+bool DistributedMatrix<ElType>::isSameMatrix(const DistributedMatrix& rhs) const {
+  if (this == &rhs)
+    return true;
+
+  if (ptr_->ptr() == rhs.ptr_->ptr() && size_ == rhs.size_ && block_size_ == rhs.block_size_ &&
+      base_index_ == rhs.base_index_ && ld_ == rhs.ld_ &&
+      leading_nr_blocks_ == rhs.leading_nr_blocks_ && distribution_ == rhs.distribution_ &&
+      comm_grid_ == rhs.comm_grid_)
+    return true;
+
+  return false;
+}
+
+template <class ElType>
 DistributedMatrix<ElType>& DistributedMatrix<ElType>::copy(const DistributedMatrix& rhs) {
   if (size_ != rhs.size_)
     throw std::invalid_argument(errorMessage("Sizes do not match: ", size_, " != ", rhs.size_));

--- a/include/dla_interface.h
+++ b/include/dla_interface.h
@@ -148,23 +148,31 @@ namespace dla_interface {
     switch (solver) {
 #ifdef DLA_HAVE_SCALAPACK
       case ScaLAPACK: {
+        std::array<int, 4> timer_index;
         util::Timer<> timer_part(comm_grid.rowOrderedMPICommunicator(), print_timers > 1);
+        timer_index[0] = 0;
         int info = 0;
-        DistributedMatrix<ElType> mat_scalapack(scalapack_dist, mat);
-        int index1 = timer_part.save_time();
-        auto matrix_info = mat_scalapack.getScalapackDescription();
+        {
+          DistributedMatrix<ElType> mat_scalapack(scalapack_dist, mat);
+          timer_index[1] = timer_part.save_time();
+          auto matrix_info = mat_scalapack.getScalapackDescription();
 
-        scalapack_wrappers::ppotrf(uplo, mat_scalapack.size().first, std::get<0>(matrix_info),
-                                   std::get<1>(matrix_info), std::get<2>(matrix_info),
-                                   &std::get<3>(matrix_info)[0], info);
+          scalapack_wrappers::ppotrf(uplo, mat_scalapack.size().first, std::get<0>(matrix_info),
+                                     std::get<1>(matrix_info), std::get<2>(matrix_info),
+                                     &std::get<3>(matrix_info)[0], info);
 
-        int index2 = timer_part.save_time();
+          timer_index[2] = timer_part.save_time();
+        }
+        timer_index[3] = timer_part.save_time();
         if (comm_grid.id2D() == std::make_pair(0, 0)) {
           double n = mat.size().first;
           double n3 = n * n * n;
           double flop = util::nrOps<ElType>(n3 / 6, n3 / 6);
-          timer_part.print_elapsed(0, index1, "Conversion a: ");
-          timer_part.print_elapsed(index1, index2, "Cholesky Factorization (ScaLAPACK) time: ", flop);
+          timer_part.print_elapsed(timer_index[0], timer_index[1], "Conversion a: ");
+
+          timer_part.print_elapsed(timer_index[1], timer_index[2],
+                                   "Cholesky Factorization (ScaLAPACK) time: ", flop);
+          timer_part.print_elapsed(timer_index[2], timer_index[3], "Back conversion a: ");
         }
         if (info != 0) {
           if (info < 0)
@@ -179,24 +187,32 @@ namespace dla_interface {
 
 #ifdef DLA_HAVE_DPLASMA
       case DPlasma: {
+        std::array<int, 4> timer_index;
         util::Timer<> timer_part(comm_grid.rowOrderedMPICommunicator(), print_timers > 1);
+        timer_index[0] = 0;
         int info = 0;
-        DistributedMatrix<ElType> mat_tile(tile_dist, mat);
-        int index1 = timer_part.save_time();
-        auto matrix_info = mat_tile.getDPlasmaDescription();
-        parsec_tiled_matrix_dc_t* dp_mat =
-            reinterpret_cast<parsec_tiled_matrix_dc_t*>(&std::get<0>(matrix_info));
+        {
+          DistributedMatrix<ElType> mat_tile(tile_dist, mat);
+          timer_index[1] = timer_part.save_time();
+          auto matrix_info = mat_tile.getDPlasmaDescription();
+          parsec_tiled_matrix_dc_t* dp_mat =
+              reinterpret_cast<parsec_tiled_matrix_dc_t*>(&std::get<0>(matrix_info));
 
-        dplasma_wrappers::dplasma_run<dplasma_wrappers::ppotrf<ElType>>(
-            std::get<1>(matrix_info), dplasma_wrappers::plasmaUpLo(uplo), dp_mat, &info);
+          dplasma_wrappers::dplasma_run<dplasma_wrappers::ppotrf<ElType>>(
+              std::get<1>(matrix_info), dplasma_wrappers::plasmaUpLo(uplo), dp_mat, &info);
 
-        int index2 = timer_part.save_time();
+          timer_index[2] = timer_part.save_time();
+        }
+        timer_index[3] = timer_part.save_time();
         if (comm_grid.id2D() == std::make_pair(0, 0)) {
           double n = mat.size().first;
           double n3 = n * n * n;
           double flop = util::nrOps<ElType>(n3 / 6, n3 / 6);
-          timer_part.print_elapsed(0, index1, "Conversion a: ");
-          timer_part.print_elapsed(index1, index2, "Cholesky Factorization (DPlasma) time: ", flop);
+          timer_part.print_elapsed(timer_index[0], timer_index[1], "Conversion a: ");
+
+          timer_part.print_elapsed(timer_index[1], timer_index[2],
+                                   "Cholesky Factorization (DPlasma) time: ", flop);
+          timer_part.print_elapsed(timer_index[2], timer_index[3], "Back conversion a: ");
         }
         if (info != 0) {
           throw std::invalid_argument(errorMessage("Matrix is not positive definite (", info, ")"));

--- a/include/dla_interface.h
+++ b/include/dla_interface.h
@@ -46,7 +46,14 @@ namespace dla_interface {
         {
           auto mat_a_scalapack_ptr = mat_a.convertConst(scalapack_dist);
           timer_index[1] = timer_part.save_time();
-          auto mat_b_scalapack_ptr = mat_b.convertConst(scalapack_dist);
+          decltype(mat_a_scalapack_ptr) mat_b_scalapack_ptr;
+          // if mat_a and mat_b are the same matrix (same memory) only mat_a is converted,
+          // otherwise convert both matrices.
+          if (mat_a.isSameMatrix(mat_b))
+            mat_b_scalapack_ptr = mat_a_scalapack_ptr;
+          else
+            mat_b_scalapack_ptr = mat_b.convertConst(scalapack_dist);
+
           timer_index[2] = timer_part.save_time();
           DistributedMatrix<ElType> mat_c_scalapack(scalapack_dist, mat_c);
           timer_index[3] = timer_part.save_time();
@@ -88,7 +95,14 @@ namespace dla_interface {
         {
           auto mat_a_tile_ptr = mat_a.convertConst(tile_dist);
           timer_index[1] = timer_part.save_time();
-          auto mat_b_tile_ptr = mat_b.convertConst(tile_dist);
+          decltype(mat_a_tile_ptr) mat_b_tile_ptr;
+          // if mat_a and mat_b are the same matrix (same memory) only mat_a is converted,
+          // otherwise convert both matrices.
+          if (mat_a.isSameMatrix(mat_b))
+            mat_b_tile_ptr = mat_a_tile_ptr;
+          else
+            mat_b_tile_ptr = mat_b.convertConst(tile_dist);
+
           timer_index[2] = timer_part.save_time();
           DistributedMatrix<ElType> mat_c_tile(tile_dist, mat_c);
           timer_index[3] = timer_part.save_time();


### PR DESCRIPTION
-Added timer information for the back-conversion of the cholesky matrix. (Closes #51)
-Convert only once if a and b are the same matrix in gemm. (Closes #52)