### PR TITLE
Other cases for fallback to ScaLAPACK

### DIFF
--- a/include/dla_interface/cholesky_factorization.ipp
+++ b/include/dla_interface/cholesky_factorization.ipp
@@ -11,6 +11,16 @@ void choleskyFactorization(UpLo uplo, DistributedMatrix<ElType>& mat, SolverType
 
   solver = dlai__util__fallbackCommunicator(comm_grid, solver);
 
+#ifdef DLA_HAVE_HPX_LINALG
+  if (solver == HPX_LINALG) {
+    solver = dlai__util__fallbackScaLAPACKCondition(uplo != Lower, comm_grid, solver,
+                                                    "HPX linalg supports only uplo == Lower.");
+    solver = dlai__util__fallbackScaLAPACKCondition(mat.baseIndex() != Global2DIndex(0, 0),
+                                                    comm_grid, solver,
+                                                    "HPX linalg supports only baseIndex = (0, 0).");
+  }
+#endif
+
   double n = mat.size().first;
   double n3 = n * n * n;
   double flop = util::nrOps<ElType>(n3 / 6, n3 / 6);

--- a/include/dla_interface/lu_factorization.ipp
+++ b/include/dla_interface/lu_factorization.ipp
@@ -15,6 +15,13 @@ void LUFactorization(DistributedMatrix<ElType>& mat, int* ipiv, SolverType solve
   dlai__util__checkBaseIndexAtBlock(mat);
 
   solver = dlai__util__fallbackCommunicator(comm_grid, solver);
+#ifdef DLA_HAVE_DPLASMA
+  if (solver == DPlasma) {
+    solver =
+        dlai__util__fallbackScaLAPACKCondition(comm_grid.size2D().first != 1, comm_grid, solver,
+                                               "DPlasma LU supports only (1 x P) process grids.");
+  }
+#endif
 
   double x = std::min(mat.size().first, mat.size().second);
   double d = std::max(mat.size().first, mat.size().second) - x;

--- a/include/dla_interface/matrix_multiplication.ipp
+++ b/include/dla_interface/matrix_multiplication.ipp
@@ -9,6 +9,20 @@ void matrixMultiplication(OpTrans trans_a, OpTrans trans_b, ElType alpha,
 
   solver = dlai__util__fallbackCommunicator(comm_grid, solver);
 
+#ifdef DLA_HAVE_DPLASMA
+  if (solver == DPlasma) {
+    int mb = mat_c.blockSize().first;
+    int nb = mat_c.blockSize().second;
+    int mb2 = trans_a == NoTrans ? mat_a.blockSize().first : mat_a.blockSize().second;
+    int kb = trans_a == NoTrans ? mat_a.blockSize().second : mat_a.blockSize().first;
+    int kb2 = trans_b == NoTrans ? mat_b.blockSize().first : mat_b.blockSize().second;
+    int nb2 = trans_b == NoTrans ? mat_b.blockSize().second : mat_b.blockSize().first;
+    solver = dlai__util__fallbackScaLAPACKCondition(
+        mb != mb2 || nb != nb2 || kb != kb2, comm_grid, solver,
+        "Matrix matrix multiplication block sizes are incompatible.");
+  }
+#endif
+
   // For real Types OpTrans 'C' and 'T' are equivalent.
   // Since DPlasma doesn't support 'C' for real types replace 'C' with 'T' for reals.
   trans_a = util::RemoveConjOpTypeIfReal<ElType>(trans_a);

--- a/include/util_fallback.h
+++ b/include/util_fallback.h
@@ -27,10 +27,23 @@ namespace dla_interface {
 #endif
       return solver;
     }
+
+    inline SolverType fallbackScaLAPACKCondition(const char* func, bool condition,
+                                                 const comm::Communicator2DGrid& comm,
+                                                 SolverType solver, std::string message) {
+      if (condition) {
+        if (comm.id2D() == std::make_pair(0, 0))
+          comm::CommunicatorManager::getFallbackInfo().report(func, solver, ScaLAPACK, message);
+        return ScaLAPACK;
+      }
+      return solver;
+    }
   }
 }
 
 #define dlai__util__fallbackCommunicator(comm, solver) \
   dla_interface::util::fallbackCommunicator(__func__, comm, solver)
+#define dlai__util__fallbackScaLAPACKCondition(condition, comm, solver, message) \
+  dla_interface::util::fallbackScaLAPACKCondition(__func__, condition, comm, solver, message)
 
 #endif  // DLA_INTERFACE_UTIL_FALLBACK_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(gtest gtest/src/gtest-all.cpp)
 target_include_directories(gtest PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gtest>)
+target_link_libraries(gtest ${MPI_CXX_LIBRARIES})
 
 add_library(gtest_main gtest/src/gtest_main.cpp)
 target_include_directories(gtest_main PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gtest>)

--- a/test/gtest/gtest/pretty_mpi_unit_test_result_printer.ipp
+++ b/test/gtest/gtest/pretty_mpi_unit_test_result_printer.ipp
@@ -1,0 +1,265 @@
+// Copyright (c) 2016, Eidgenössische Technische Hochschule Zürich and
+// Forschungszentrum Jülich GmbH.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Source: Arbor library
+// Note: the file has the following modifications:
+//       - plain MPI functions
+//       - rank 0 uses PrettyUnitTestResultPrinter output style
+//         when printing to standard output.
+
+#ifndef GTEST_PRETTY_MPI_UNIT_TEST_RESULT_PRINTER_H
+#define GTEST_PRETTY_MPI_UNIT_TEST_RESULT_PRINTER_H
+
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+
+#include <mpi.h>
+
+#include "gtest/gtest.h"
+
+/// A specialized listener designed for printing test results with MPI.
+///
+/// When tests are run with MPI, one instance of each test is run on
+/// each rank. The default behavior of Google Test is for each test
+/// instance to print to stdout. With more than one MPI rank, this creates
+/// the usual MPI mess of output.
+///
+/// This specialization has the first rank (rank 0) print to stdout, and all MPI
+/// ranks print their output to separate text files.
+/// For each test a message is printed showing
+///     - detailed messages about errors on rank 0
+///     - a head count of errors that occured on other MPI ranks
+#define skip_printing_failure "**** should not be printed ****"
+
+namespace testing {
+  namespace internal {
+    AssertionResult AssertTestPassedGlobally(const char*, const std::vector<int>& failures) {
+      bool flag = true;
+      for (size_t i = 0; i < failures.size(); ++i) {
+        if (failures[i] > 0) {
+          std::cout << "    Rank " << i << " FAILED " << failures[i] << " tests\n" << std::endl;
+          flag = false;
+        }
+      }
+      return flag ? AssertionSuccess() : AssertionFailure();
+    }
+  }
+
+  class PrettyMpiUnitTestResultPrinter : public internal::PrettyUnitTestResultPrinter {
+    private:
+    int rank_;
+    int size_;
+    std::ofstream fid_;
+    char buffer_[1024];
+    int test_case_failures_;
+    int test_case_tests_;
+    int test_failures_;
+
+    bool does_print() const {
+      return rank_ == 0;
+    }
+
+    void print(const char* s) {
+      if (fid_) {
+        fid_ << s;
+      }
+    }
+
+    void print(const std::string& s) {
+      print(s.c_str());
+    }
+
+    /// convenience function that handles the logic of using snprintf
+    /// and forwarding the results to file and/or stdout.
+    template <typename... Args>
+    void printf_helper(const char* s, Args&&... args) {
+      std::snprintf(buffer_, sizeof(buffer_), s, std::forward<Args>(args)...);
+      print(buffer_);
+    }
+
+    public:
+    PrettyMpiUnitTestResultPrinter(std::string f_base = "") {
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+      MPI_Comm_size(MPI_COMM_WORLD, &size_);
+
+      if (f_base.empty()) {
+        return;
+      }
+      std::string fname = f_base + "_" + std::to_string(rank_) + ".txt";
+      fid_.open(fname);
+      if (!fid_) {
+        throw std::runtime_error("could not open file " + fname + " for test output");
+      }
+    }
+
+    // Returns the file stream (can be used to output extra informations durint the test)
+    std::ofstream& outStream() {
+      return fid_;
+    }
+
+    /// Messages that are printed at the start and end of the test program.
+    /// i.e. once only.
+    virtual void OnTestProgramStart(const UnitTest&) override {
+      printf_helper("*** test output for rank %d of %d\n\n", rank_, size_);
+    }
+    virtual void OnTestProgramEnd(const UnitTest&) override {
+      printf_helper("*** end test output for rank %d of %d\n", rank_, size_);
+    }
+
+    virtual void OnEnvironmentsSetUpStart(const UnitTest& unit_test) override {
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnEnvironmentsSetUpStart(unit_test);
+      }
+    }
+    /// Messages that are printed at the start and end of each test case.
+    /// On startup a counter that counts the number of tests that fail in
+    /// this test case is initialized to zero, and will be incremented for each
+    /// test that fails.
+    virtual void OnTestCaseStart(const TestCase& test_case) override {
+      test_case_failures_ = 0;
+      test_case_tests_ = 0;
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnTestCaseStart(test_case);
+      }
+    }
+    virtual void OnTestCaseEnd(const TestCase& test_case) override {
+      printf_helper("    PASSED %d of %d tests in %s\n", test_case_tests_ - test_case_failures_,
+                    test_case_tests_, test_case.name());
+      if (test_case_failures_ > 0) {
+        printf_helper("    FAILED %d of %d tests in %s\n", test_case_failures_, test_case_tests_,
+                      test_case.name());
+      }
+      print("\n");
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnTestCaseEnd(test_case);
+      }
+    }
+
+    // Called before a test starts.
+    virtual void OnTestStart(const TestInfo& test_info) override {
+      printf_helper("TEST:  %s::%s\n", test_info.test_case_name(), test_info.name());
+      test_failures_ = 0;
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnTestStart(test_info);
+      }
+    }
+
+    virtual void OnTestIterationStart(const UnitTest& unit_test, int iteration) override {
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnTestIterationStart(unit_test, iteration);
+      }
+    }
+
+    // Called after a failed assertion or a SUCCEED() invocation.
+    virtual void OnTestPartResult(const TestPartResult& test_part_result) override {
+      if (strcmp(test_part_result.message(), skip_printing_failure) == 0)
+        return;
+
+      // indent all lines in the summary by 4 spaces
+      std::string summary = "    " + std::string(test_part_result.summary());
+      auto pos = summary.find("\n");
+      while (pos != summary.size() && pos != std::string::npos) {
+        summary.replace(pos, 1, "\n    ");
+        pos = summary.find("\n", pos + 1);
+      }
+
+      printf_helper("  LOCAL_%s\n    %s:%d\n%s\n", test_part_result.failed() ? "FAIL" : "SUCCESS",
+                    test_part_result.file_name(), test_part_result.line_number(), summary.c_str());
+
+      // note that there was a failure in this test case
+      if (test_part_result.failed()) {
+        test_failures_++;
+      }
+
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnTestPartResult(test_part_result);
+      }
+    }
+
+    virtual void OnTestIterationEnd(const UnitTest& unit_test, int iteration) override {
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnTestIterationEnd(unit_test, iteration);
+      }
+    }
+
+    // Called after a test ends.
+    virtual void OnTestEnd(const TestInfo& test_info) override {
+      test_case_tests_++;
+
+      // gather the number of failures to report them
+      std::vector<int> failures(size_);
+      MPI_Allgather(&test_failures_, 1, MPI_INT, &failures[0], 1, MPI_INT, MPI_COMM_WORLD);
+
+      // count the number of ranks that had errors
+      int local_error = test_failures_ > 0;
+      int global_errors = 0;
+      MPI_Allreduce(&local_error, &global_errors, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+      if (global_errors > 0) {
+        test_case_failures_++;
+        printf_helper("  GLOBAL_FAIL on %d ranks\n", global_errors);
+        for (size_t i = 0; i < failures.size(); ++i) {
+          if (failures[i] > 0)
+            printf_helper("    Rank %d FAILED %d tests\n", i, failures[i]);
+        }
+      }
+      if (does_print()) {
+        for (size_t i = 0; i < failures.size(); ++i) {
+          if (failures[i] > 0) {
+            std::cout << "    Rank " << i << " FAILED " << failures[i] << " tests" << std::endl;
+            GTEST_NONFATAL_FAILURE_(skip_printing_failure);
+          }
+        }
+        PrettyUnitTestResultPrinter::OnTestEnd(test_info);
+      }
+    }
+
+    virtual void OnEnvironmentsTearDownStart(const UnitTest& unit_test) override {
+      if (does_print()) {
+        PrettyUnitTestResultPrinter::OnEnvironmentsTearDownStart(unit_test);
+      }
+    }
+  };
+
+  // Set the unit test listener to PrettyMpiUnitTestResultPrinter.
+  // The name of the output files is f_base + "_" + mpi_rank.txt
+  std::ofstream& setMPIListener(std::string f_base) {
+    auto& listeners = testing::UnitTest::GetInstance()->listeners();
+    // first delete the original printer
+    delete listeners.Release(listeners.default_result_printer());
+    // now add our custom printer
+    auto mpi_listener = new PrettyMpiUnitTestResultPrinter(f_base);
+    listeners.Append(mpi_listener);
+
+    return mpi_listener->outStream();
+  }
+}
+
+#endif

--- a/test/gtest/src/gtest.cpp
+++ b/test/gtest/src/gtest.cpp
@@ -5404,5 +5404,7 @@ std::string TempDir() {
   return "/tmp/";
 #endif  // GTEST_OS_WINDOWS_MOBILE
 }
-
 }  // namespace testing
+
+// result printer that avoids multiple ranks to print to stdout.
+#include "gtest/pretty_mpi_unit_test_result_printer.ipp"

--- a/test/include/mpi_listener.h
+++ b/test/include/mpi_listener.h
@@ -1,0 +1,11 @@
+#ifndef DLA_INTERFACE_TEST_INCLUDE_MPI_LISTENER_H
+#define DLA_INTERFACE_TEST_INCLUDE_MPI_LISTENER_H
+
+#include <fstream>
+
+namespace testing {
+  std::ofstream& setMPIListener(std::string f_base);
+  // Implemented in pretty_mpi_unit_test_result_printer.ipp
+}
+
+#endif  // DLA_INTERFACE_TEST_INCLUDE_MPI_LISTENER_H

--- a/test/unit/test_communicator_grid.cpp
+++ b/test/unit/test_communicator_grid.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include "blacs.h"
 #include "gtest/gtest.h"
+#include "mpi_listener.h"
 #include "util_mpi.h"
 
 // This tests have to be execuuted using 6 MPI ranks.
@@ -216,6 +217,9 @@ int main(int argc, char** argv) {
   mpi_comms.push_back(tmp);
 
   ::testing::InitGoogleTest(&argc, argv);
+
+  // set up a custom listener that prints messages in an MPI-friendly way
+  ::testing::setMPIListener("results_test_communicator_grid");
 
   auto ret = RUN_ALL_TESTS();
 

--- a/test/unit/test_communicator_manager.cpp
+++ b/test/unit/test_communicator_manager.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <vector>
 #include "gtest/gtest.h"
+#include "mpi_listener.h"
 #include "communicator_grid.h"
 #include "util_mpi.h"
 
@@ -206,6 +207,12 @@ int main(int argc, char** argv) {
   mpi_comms.push_back(tmp);
 
   ::testing::InitGoogleTest(&argc, argv);
+
+#ifdef COMM_INITS_MPI
+  ::testing::setMPIListener("results_test_communicator_manager_init");
+#else
+  ::testing::setMPIListener("results_test_communicator_manager");
+#endif
 
   auto ret = RUN_ALL_TESTS();
 

--- a/test/unit/test_distributed_matrix.cpp
+++ b/test/unit/test_distributed_matrix.cpp
@@ -6,6 +6,7 @@
 #include "communicator_manager.h"
 #include "local_matrix.h"
 #include "gtest/gtest.h"
+#include "mpi_listener.h"
 #include "null_stream.h"
 #include "util_local_matrix.h"
 #include "util_distributed_matrix.h"
@@ -1926,6 +1927,8 @@ int main(int argc, char** argv) {
   }
 
   ::testing::InitGoogleTest(&argc, argv);
+
+  ::testing::setMPIListener("results_test_distributed_matrix");
 
   auto ret = RUN_ALL_TESTS();
 

--- a/test/unit/test_dla_interface.cpp
+++ b/test/unit/test_dla_interface.cpp
@@ -71,10 +71,8 @@ TYPED_TEST(DLATypedTest, CholeskyFactorization) {
           auto A1 = std::make_shared<DistributedMatrix<ElType>>(n, n, nb, nb, *comm_ptr, dist);
           auto A2 =
               DistributedMatrix<ElType>(n + nb, n + nb, nb, nb, *comm_ptr, dist).subMatrix(n, n, nb, nb);
-          std::vector<std::shared_ptr<DistributedMatrix<ElType>>> mats{A1};
-          if (solver != HPX_LINALG) mats.push_back(A2);
-          if (solver == HPX_LINALG && uplo != Lower) continue;
-          for (auto A_ptr : mats) {
+
+          for (auto A_ptr : {A1, A2}) {
             auto& A = *A_ptr;
             fillDistributedMatrix(A, el_val);
 

--- a/test/unit/test_dla_interface.cpp
+++ b/test/unit/test_dla_interface.cpp
@@ -127,10 +127,6 @@ TYPED_TEST(DLATypedTest, LUFactorization) {
     for (auto comm_ptr : comms) {
       for (auto dist : dists) {
         for (auto solver : solvers) {
-          // DPlasma supports only 1D communicators for LU.
-          if (solver == DPlasma && comm_ptr->size2D().first != 1)
-            continue;
-
           auto A1 = std::make_shared<DistributedMatrix<ElType>>(m, n, nb, nb, *comm_ptr, dist);
           auto A2 = DistributedMatrix<ElType>(m + nb, n + 2 * nb, nb, nb, *comm_ptr, dist)
                         .subMatrix(m, n, nb, 2 * nb);

--- a/test/unit/test_dla_interface.cpp
+++ b/test/unit/test_dla_interface.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <stdexcept>
 #include "gtest/gtest.h"
+#include "mpi_listener.h"
 #include "util_complex.h"
 #include "util_distributed_matrix.h"
 #include "communicator_grid.h"
@@ -267,7 +268,11 @@ int main(int argc, char** argv) {
     comms.push_back(&comm::CommunicatorManager::createCommunicator2DGrid(MPI_COMM_WORLD, 1, 6, order));
   }
 
+  comm::CommunicatorManager::getFallbackInfo().setFullReport(true);
+
   ::testing::InitGoogleTest(&argc, argv);
+
+  ::testing::setMPIListener("results_test_dla_interface");
 
   auto ret = RUN_ALL_TESTS();
 


### PR DESCRIPTION
DPlasma -> ScaLAPACK: 
- LU: grid != (1 x P)
- matrix multiplication: incompatible blocksizes

HPX_linalg:
- Cholesky decomposition: uplo != Lower
- Cholesky decomposition: baseIndex != (0, 0)